### PR TITLE
Add PopulationProxyTargets (proxy target overfitting bias)

### DIFF
--- a/mlsim/bias/__init__.py
+++ b/mlsim/bias/__init__.py
@@ -1,4 +1,4 @@
-from .populations import Population, PopulationInstantiated
+from .populations import Population, PopulationInstantiated, PopulationProxyTargets
 from .bias_components import Demographic, DemographicIndependent, DemographicCorrelated
 from .bias_components import Target, TargetDisadvantagedError, TargetTwoError
 from .bias_components import Feature,FeatureSharedParam,FeatureTwoParams
@@ -7,7 +7,7 @@ from .bias_components import FeaturePerGroupSharedParamAcrossGroups
 from .bias_components import FeatureMeasurementQualityProxy
 from .bias_components import FeatureNoise, FeatureNoiseReplace
 
-__all__  = ['Population','PopulationInstantiated',  'Demographic',
+__all__  = ['Population','PopulationInstantiated', 'PopulationProxyTargets', 'Demographic',
     'DemographicIndependent', 'DemographicCorrelated',  'Target',
     'TargetDisadvantagedError', 'TargetTwoError',  'Feature','FeatureSharedParam',
     'FeatureTwoParams',  'FeaturePerGroupTwoParam',

--- a/mlsim/bias/populations.py
+++ b/mlsim/bias/populations.py
@@ -274,7 +274,8 @@ class PopulationProxyTargets(PopulationInstantiated):
         y = self.target_sampler.sample(a, z)
 
         x_true  = self.feature_sampler.sample(a, z, y)
-        x_proxy = self.feature_sampler_proxy.sample(a, y, y)  # y in z slot = proxy trick
+        # y in z slot = proxy trick
+        x_proxy = self.feature_sampler_proxy.sample(a, y, y) 
         x = np.concatenate([x_true, x_proxy], axis=1)
         x = self.feature_noise_sampler.sample(a, z, y, x)
 

--- a/mlsim/bias/populations.py
+++ b/mlsim/bias/populations.py
@@ -193,3 +193,94 @@ class PopulationInstantiated(Population):
         self.target_sampler = target_sampler
         self.feature_sampler = feature_sampler
         self.feature_noise_sampler = feature_noise_sampler
+
+
+class PopulationProxyTargets(PopulationInstantiated):
+    '''
+    Population for proxy target overfitting bias.
+
+    Generates a population whose features are split into two sets: one set is
+    informative of the true target ``z`` and a second "proxy" set is
+    informative of the observed, possibly biased, target ``y``. When ``y``
+    differs from ``z`` more often for one protected group (for example using
+    ``TargetTwoError``), a model trained on ``y`` can rely on the proxy
+    features and be systematically wrong about ``z`` for that group, producing
+    a per-group accuracy gap.
+
+    Parameters
+    ----------
+    demographic_sampler : Demographic
+        Sampler for the protected attribute ``a`` and the true target ``z``.
+    target_sampler : Target
+        Sampler for the observed target ``y``; use a sampler with per-group
+        label error (e.g. ``TargetTwoError``) so that ``y != z`` more for
+        one group.
+    feature_sampler_true : Feature
+        Sampler for features informative of the true target ``z``; sampled as
+        ``sample(a, z, y)``.
+    feature_sampler_proxy : Feature
+        Sampler for features informative of the proxy target ``y``; sampled as
+        ``sample(a, y, y)`` so its class locations follow the observed label
+        instead of the truth.
+    feature_noise_sampler : FeatureNoise
+        Sampler that adds noise to the concatenated feature matrix, applied as
+        ``sample(a, z, y, x)``.
+
+    See Also
+    --------
+    PopulationInstantiated : parent class taking instantiated samplers.
+    TargetTwoError : per-group label error so that ``y != z`` more for one group.
+
+    Notes
+    -----
+    The proxy features are produced by passing ``y`` in the position the base
+    samplers use for ``z``; this is the mechanism that makes them track the
+    observed label rather than the truth.
+    '''
+
+    def __init__(self, demographic_sampler=Demographic(),
+                target_sampler=Target(),
+                feature_sampler_true=Feature(),
+                feature_sampler_proxy=Feature(),
+                feature_noise_sampler=FeatureNoise()):
+        self.demographic_sampler = demographic_sampler
+        self.target_sampler = target_sampler
+        self.feature_sampler = feature_sampler_true
+        self.feature_sampler_proxy = feature_sampler_proxy
+        self.feature_noise_sampler = feature_noise_sampler
+
+    def sample(self, N, return_as='DataFrame'):
+        '''
+        Sample ``N`` members of the population.
+
+        The returned feature columns are the true-target features followed by
+        the proxy-target features.
+
+        Parameters
+        ----------
+        N : int
+            Number of samples to draw.
+        return_as : string, 'DataFrame'
+            Type to return as, either pandas ``'DataFrame'`` or IBM AIF360
+            ``'structuredDataset'``.
+
+        Returns
+        -------
+        df : pandas.DataFrame or aif360.datasets.StructuredDataset
+            Columns ``a``, ``z``, ``y`` followed by the feature columns
+            ``x0 ... x(d_true + d_proxy - 1)``.
+        '''
+        a, z = self.demographic_sampler.sample(N)
+        y = self.target_sampler.sample(a, z)
+
+        x_true  = self.feature_sampler.sample(a, z, y)
+        x_proxy = self.feature_sampler_proxy.sample(a, y, y)  # y in z slot = proxy trick
+        x = np.concatenate([x_true, x_proxy], axis=1)
+        x = self.feature_noise_sampler.sample(a, z, y, x)
+
+        if return_as == 'DataFrame':
+            df = self.make_DataFrame(a, z, y, x)
+        elif return_as == 'structuredDataset':
+            df = self.make_StructuredDataset(a, z, y, x)
+
+        return df

--- a/tests/test_populations.py
+++ b/tests/test_populations.py
@@ -81,3 +81,63 @@ def test_feature_sampler():
 
 #def test_feature_noise_sampler():
     # TODO: Check For Noise
+
+
+def test_proxy_targets_constructor():
+    # default construction works and is a Population subclass
+    pop = bias.PopulationProxyTargets()
+    assert isinstance(pop, bias.Population)
+    # default noise sampler is set (matches parent convention, not None)
+    assert pop.feature_noise_sampler.__dict__ == bias.FeatureNoise().__dict__
+
+
+def test_proxy_targets_columns_and_shape():
+    pop = bias.PopulationProxyTargets(
+        feature_sampler_true=bias.FeatureTwoParams(loc=[[0, 0], [3, 3]],
+                                                   spread=[1, 1]),
+        feature_sampler_proxy=bias.FeatureTwoParams(loc=[[-2.5, -2.5], [2.5, 2.5]],
+                                                    spread=[1, 1]),
+    )
+    df = pop.sample(500)
+    # a, z, y + 2 truth features + 2 proxy features
+    assert list(df.columns) == ['a', 'z', 'y', 'x0', 'x1', 'x2', 'x3']
+    assert df.shape == (500, 7)
+
+
+def test_proxy_targets_label_error_per_group():
+    # the bias source: group 0 has much more label error (y != z) than group 1
+    pop = bias.PopulationProxyTargets(
+        demographic_sampler=bias.DemographicCorrelated(rho_a=0.5, rho_z=[0.5, 0.5]),
+        target_sampler=bias.TargetTwoError(beta=[0.45, 0.05]),
+    )
+    df = pop.sample(6000)
+    err0 = (df[df['a'] == 0]['y'] != df[df['a'] == 0]['z']).mean()
+    err1 = (df[df['a'] == 1]['y'] != df[df['a'] == 1]['z']).mean()
+    assert err0 > err1
+    assert abs(err0 - 0.45) < 0.05
+    assert abs(err1 - 0.05) < 0.03
+
+
+def test_proxy_targets_accuracy_gap():
+    # optional: needs scikit-learn (pulled in transitively by aif360)
+    import pytest
+    pytest.importorskip("sklearn")
+    from sklearn.naive_bayes import GaussianNB
+    from sklearn.model_selection import train_test_split
+    from sklearn.metrics import accuracy_score
+
+    pop = bias.PopulationProxyTargets(
+        demographic_sampler=bias.DemographicCorrelated(rho_a=0.5, rho_z=[0.5, 0.5]),
+        target_sampler=bias.TargetTwoError(beta=[0.45, 0.05]),
+        feature_sampler_true=bias.FeatureTwoParams(loc=[[0, 0], [3, 3]], spread=[1, 1]),
+        feature_sampler_proxy=bias.FeatureTwoParams(loc=[[-2.5, -2.5], [2.5, 2.5]],
+                                                    spread=[1, 1]),
+    )
+    df = pop.sample(5000)
+    feats = ['x0', 'x1', 'x2', 'x3']
+    tr, te = train_test_split(df, test_size=0.3, random_state=0)
+    pred = GaussianNB().fit(tr[feats], tr['y']).predict(te[feats])
+    g0 = accuracy_score(te['z'][te['a'] == 0], pred[te['a'] == 0])
+    g1 = accuracy_score(te['z'][te['a'] == 1], pred[te['a'] == 1])
+    # a=0 (more label error) is worse on the true target than a=1
+    assert g0 < g1


### PR DESCRIPTION
Adds `PopulationProxyTargets`, a `Population` subclass that generates data with
**proxy target overfitting bias**